### PR TITLE
[CI] Disable Java tests

### DIFF
--- a/.github/workflows/misc-tests.yml
+++ b/.github/workflows/misc-tests.yml
@@ -39,6 +39,7 @@ jobs:
       run: |
         bash ops/test-sdist.sh
   java-test:
+    if: false   # TODO(hcho3): Re-enable when Java runtime is brought up to date
     name: Run Java tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The Java runtime is not yet compatible with the updated TL2cgen. Disable the Java tests until the Java runtime can be brought back to up-to-date.