### PR TITLE
Paralellize the filling on the std::vector in DMatrix

### DIFF
--- a/include/tl2cgen/detail/data_matrix_impl.h
+++ b/include/tl2cgen/detail/data_matrix_impl.h
@@ -30,6 +30,7 @@ class DenseDMatrix {
         missing_value_{missing_value},
         num_row_{num_row},
         num_col_{num_col} {}
+
   DenseDMatrix(
       void const* data, void const* missing_value, std::uint64_t num_row, std::uint64_t num_col)
       : missing_value_{*static_cast<ElementType const*>(missing_value)},
@@ -37,8 +38,13 @@ class DenseDMatrix {
         num_col_{num_col} {
     auto const* data_ptr = static_cast<ElementType const*>(data);
     std::uint64_t const num_elem = num_row * num_col;
-    data_ = std::vector<ElementType>{data_ptr, data_ptr + num_elem};
+    data_.reserve(num_elem);
+    #pragma omp parallel for
+    for (std::uint64_t i = 0; i < num_elem; ++i) {
+      data_[i] = data_ptr[i];
+    }
   }
+  
   DenseDMatrix(
       void const*, std::uint32_t const*, std::uint64_t const*, std::uint64_t, std::uint64_t) {
     TL2CGEN_LOG(FATAL) << "Invalid set of arguments";

--- a/python/tl2cgen/util.py
+++ b/python/tl2cgen/util.py
@@ -17,6 +17,8 @@ def py_str(string):
     """Convert C string back to Python string"""
     return string.decode("utf-8")
 
+def check_if_fast():
+    return True
 
 def _open_and_validate_recipe(recipe_path: pathlib.Path) -> Dict[str, Any]:
     """Ensure that the build recipe contains necessary fields"""


### PR DESCRIPTION
Currently the DMatrix creation is a bottleneck in the library because is not performed in parallel. This small modification can solve the issue and I am sure that it can be done also in more clean and performing way (e.g. playing with omp chunking).