### PR TITLE
Thresh_as_int parameter added

### DIFF
--- a/include/tl2cgen/compiler_param.h
+++ b/include/tl2cgen/compiler_param.h
@@ -32,6 +32,8 @@ struct CompilerParam {
              compilation time and reduce memory consumption during
              compilation. */
   int parallel_comp{0};
+  /*! \brief Wether to interpret threshold points as integers (0: no, >0: yes) */
+  bool thresh_as_int{false};
   /*! \brief If >0, produce extra messages */
   int verbose{0};
   /*! \brief Native lib name (without extension) */

--- a/include/tl2cgen/detail/compiler/ast/ast.h
+++ b/include/tl2cgen/detail/compiler/ast/ast.h
@@ -94,15 +94,17 @@ class NumericalConditionNode : public ConditionNode {
  public:
   using ThresholdVariantT = std::variant<float, double>;
   NumericalConditionNode(std::uint32_t split_index, bool default_left, treelite::Operator op,
-      ThresholdVariantT threshold, std::optional<int> quantized_threshold)
+      ThresholdVariantT threshold, std::optional<int> quantized_threshold, bool thresh_as_int)
       : ConditionNode(split_index, default_left),
         op_(op),
         threshold_(threshold),
         quantized_threshold_(quantized_threshold),
+        thresh_as_int_(thresh_as_int),
         zero_quantized_(-1) {}
   treelite::Operator op_;
   ThresholdVariantT threshold_;
   std::optional<int> quantized_threshold_;
+  bool thresh_as_int_;
   int zero_quantized_;  // quantized value of 0.0f (useful when convert_missing_to_zero is set)
   std::string GetDump() const override;
 };

--- a/include/tl2cgen/detail/compiler/ast/builder.h
+++ b/include/tl2cgen/detail/compiler/ast/builder.h
@@ -33,7 +33,7 @@ class ASTBuilder {
   ASTBuilder() : main_node_(nullptr) {}
 
   /* \brief Initially build AST from model */
-  void BuildAST(treelite::Model const& model);
+  void BuildAST(treelite::Model const& model, bool thresh_as_int);
   /* \brief Generate is_categorical[] array, which tells whether each feature
             is categorical or numerical */
   void GenerateIsCategoricalArray();
@@ -69,7 +69,7 @@ class ASTBuilder {
   template <typename ThresholdType, typename LeafOutputType>
   ASTNode* BuildASTFromTree(ASTNode* parent,
       treelite::Tree<ThresholdType, LeafOutputType> const& tree, int tree_id,
-      std::int32_t target_id, std::int32_t class_id, int nid);
+      std::int32_t target_id, std::int32_t class_id, int nid, bool thresh_as_int);
 
   // Keep tract of all nodes built so far, to prevent memory leak
   std::vector<std::unique_ptr<ASTNode>> nodes_;

--- a/src/compiler/ast/build.cc
+++ b/src/compiler/ast/build.cc
@@ -109,7 +109,7 @@ ASTNode* ASTBuilder::BuildASTFromTree(ASTNode* parent,
   } else {
     if (tree.NodeType(nid) == treelite::TreeNodeType::kNumericalTestNode) {
       ast_node = AddNode<NumericalConditionNode>(parent, tree.SplitIndex(nid),
-          tree.DefaultLeft(nid), tree.ComparisonOp(nid), tree.Threshold(nid), std::nullopt);
+          tree.DefaultLeft(nid), tree.ComparisonOp(nid), tree.Threshold(nid), std::nullopt, thresh_as_int);
     } else {
       ast_node = AddNode<CategoricalConditionNode>(parent, tree.SplitIndex(nid),
           tree.DefaultLeft(nid), tree.CategoryList(nid), tree.CategoryListRightChild(nid));

--- a/src/compiler/ast/build.cc
+++ b/src/compiler/ast/build.cc
@@ -56,7 +56,7 @@ std::optional<std::vector<std::int32_t>> ComputeAverageFactor(treelite::Model co
 
 namespace tl2cgen::compiler::detail::ast {
 
-void ASTBuilder::BuildAST(treelite::Model const& model) {
+void ASTBuilder::BuildAST(treelite::Model const& model, bool thresh_as_int) {
   main_node_ = AddNode<MainNode>(
       nullptr, model.base_scores.AsVector(), ComputeAverageFactor(model), model.postprocessor);
   meta_.num_target_ = model.num_target;
@@ -72,7 +72,7 @@ void ASTBuilder::BuildAST(treelite::Model const& model) {
       [&](auto&& model_preset) {
         for (std::size_t tree_id = 0; tree_id < model_preset.trees.size(); ++tree_id) {
           ASTNode* tree_head = BuildASTFromTree(func, model_preset.trees[tree_id],
-              static_cast<int>(tree_id), model.target_id[tree_id], model.class_id[tree_id], 0);
+              static_cast<int>(tree_id), model.target_id[tree_id], model.class_id[tree_id], 0, thresh_as_int);
           func->children_.push_back(tree_head);
         }
         using ModelPresetT = std::remove_const_t<std::remove_reference_t<decltype(model_preset)>>;
@@ -97,7 +97,7 @@ void ASTBuilder::BuildAST(treelite::Model const& model) {
 template <typename ThresholdType, typename LeafOutputType>
 ASTNode* ASTBuilder::BuildASTFromTree(ASTNode* parent,
     treelite::Tree<ThresholdType, LeafOutputType> const& tree, int tree_id, std::int32_t target_id,
-    std::int32_t class_id, int nid) {
+    std::int32_t class_id, int nid, bool thresh_as_int) {
   ASTNode* ast_node = nullptr;
   if (tree.IsLeaf(nid)) {
     if (meta_.leaf_vector_shape_[0] == 1 && meta_.leaf_vector_shape_[1] == 1) {
@@ -118,9 +118,9 @@ ASTNode* ASTBuilder::BuildASTFromTree(ASTNode* parent,
       dynamic_cast<ConditionNode*>(ast_node)->gain_ = tree.Gain(nid);
     }
     ast_node->children_.push_back(
-        BuildASTFromTree(ast_node, tree, tree_id, target_id, class_id, tree.LeftChild(nid)));
+        BuildASTFromTree(ast_node, tree, tree_id, target_id, class_id, tree.LeftChild(nid), thresh_as_int));
     ast_node->children_.push_back(
-        BuildASTFromTree(ast_node, tree, tree_id, target_id, class_id, tree.RightChild(nid)));
+        BuildASTFromTree(ast_node, tree, tree_id, target_id, class_id, tree.RightChild(nid), thresh_as_int));
   }
   ast_node->node_id_ = nid;
   ast_node->tree_id_ = tree_id;
@@ -135,8 +135,8 @@ ASTNode* ASTBuilder::BuildASTFromTree(ASTNode* parent,
 }
 
 template ASTNode* ASTBuilder::BuildASTFromTree(
-    ASTNode*, treelite::Tree<float, float> const&, int, std::int32_t, std::int32_t, int);
+    ASTNode*, treelite::Tree<float, float> const&, int, std::int32_t, std::int32_t, int, bool);
 template ASTNode* ASTBuilder::BuildASTFromTree(
-    ASTNode*, treelite::Tree<double, double> const&, int, std::int32_t, std::int32_t, int);
+    ASTNode*, treelite::Tree<double, double> const&, int, std::int32_t, std::int32_t, int, bool);
 
 }  // namespace tl2cgen::compiler::detail::ast

--- a/src/compiler/codegen/condition_node.cc
+++ b/src/compiler/codegen/condition_node.cc
@@ -15,7 +15,6 @@
 
 #include <cstdint>
 #include <string>
-#include <iostream>
 
 using namespace fmt::literals;
 

--- a/src/compiler/codegen/condition_node.cc
+++ b/src/compiler/codegen/condition_node.cc
@@ -15,6 +15,7 @@
 
 #include <cstdint>
 #include <string>
+#include <iostream>
 
 using namespace fmt::literals;
 
@@ -46,6 +47,14 @@ std::string double_to_bin(double number) {
     return ss.str();
 }
 
+std::string getOppositeOperator(const std::string& op) {
+    if (op == "<") return ">=";
+    else if (op == ">") return "<=";
+    else if (op == "<=") return ">";
+    else if (op == ">=") return "<";
+    else return "";  // unknown operator
+}
+
 std::string thresh_as_int(const std::string& threshold_type, ast::NumericalConditionNode const* node) {
       std::string negatstring = "";
       float splitval = std::get<float>(node->threshold_);
@@ -63,14 +72,6 @@ std::string thresh_as_int(const std::string& threshold_type, ast::NumericalCondi
       +negatstring+")"+op+"(("+new_dtype+")("+split_val_bin+"))";
 }
 
-std::string getOppositeOperator(const std::string& op) {
-    if (op == "<") return ">=";
-    else if (op == ">") return "<=";
-    else if (op == "<=") return ">";
-    else if (op == ">=") return "<";
-    else return "";  // unknown operator
-}
-
 inline std::string ExtractNumericalCondition(ast::NumericalConditionNode const* node) {
   std::string const threshold_type = codegen::GetThresholdCType(node);
   std::string result;
@@ -81,8 +82,8 @@ inline std::string ExtractNumericalCondition(ast::NumericalConditionNode const* 
   } else if (node->thresh_as_int_) { // Threshold as integer
     if (!(threshold_type == "float" || threshold_type == "double")) { // Only float and double are supported
       throw std::runtime_error("Invalid threshold type.");
+    }
     result = thresh_as_int(threshold_type, node);
-  }
   } else {
     result = std::visit(
         [&](auto&& threshold) -> std::string {

--- a/src/compiler/compiler.cc
+++ b/src/compiler/compiler.cc
@@ -26,7 +26,7 @@ detail::ast::ASTBuilder LowerToAST(
     treelite::Model const& model, tl2cgen::compiler::CompilerParam const& param) {
   /* 1. Lower the tree ensemble model into Abstract Syntax Tree (AST) */
   detail::ast::ASTBuilder builder;
-  builder.BuildAST(model);
+  builder.BuildAST(model, param.thresh_as_int);
 
   /* 2. Apply optimization passes to AST */
   if (param.annotate_in != "NULL") {

--- a/src/compiler/compiler_param.cc
+++ b/src/compiler/compiler_param.cc
@@ -26,6 +26,10 @@ CompilerParam CompilerParam::ParseFromJSON(char const* param_json_str) {
       TL2CGEN_CHECK(e.value.IsInt()) << "Expected an integer for 'quantize'";
       param.quantize = e.value.GetInt();
       TL2CGEN_CHECK_GE(param.quantize, 0) << "'quantize' must be 0 or greater";
+    } else if (key == "thresh_as_int") {
+      TL2CGEN_CHECK(e.value.IsInt()) << "Expected an integer for 'thresh_as_int'";
+      param.thresh_as_int = e.value.GetInt();
+      TL2CGEN_CHECK_GE(param.quantize, 0) << "'thresh_as_int' must be 0 or greater";
     } else if (key == "parallel_comp") {
       TL2CGEN_CHECK(e.value.IsInt()) << "Expected an integer for 'parallel_comp'";
       param.parallel_comp = e.value.GetInt();


### PR DESCRIPTION
Added functionality to be able to interpret the thresholds as integers, using an optional parameter.
This increases the performance up to 30%, without loss of accuracy.

The implementation is based on the following paper:
https://ieeexplore.ieee.org/abstract/document/10546851