### PR TITLE
Change the type of variable "missing" in Entry when fvalue type is double

### DIFF
--- a/include/tl2cgen/predictor.h
+++ b/include/tl2cgen/predictor.h
@@ -28,6 +28,11 @@ namespace detail {
 
 class SharedLibrary;
 
+template <typename ElementType>
+struct MissingValue { using type = int; };
+template <>
+struct MissingValue<double> { using type = long; };
+
 /*!
  * \brief Data layout. The value -1 signifies the missing value.
  *        When the "missing" field is set to -1, the "fvalue" field is set to
@@ -36,7 +41,7 @@ class SharedLibrary;
  */
 template <typename ElementType>
 union Entry {
-  int missing;
+  typename MissingValue<ElementType>::type missing;
   ElementType fvalue;
 };
 

--- a/src/compiler/codegen/main_node.cc
+++ b/src/compiler/codegen/main_node.cc
@@ -71,7 +71,7 @@ char const* const header_template =
 #define MAX_N_CLASS {max_num_class}
 
 union Entry {{
-  int missing;
+  {missing_ctype} missing;
   {threshold_ctype} fvalue;
   int qvalue;
 }};
@@ -119,11 +119,13 @@ void HandleMainNode(ast::MainNode const* node, CodeCollection& gencode) {
   std::int32_t const num_target = node->meta_->num_target_;
   std::vector<std::int32_t>& num_class = node->meta_->num_class_;
   std::int32_t const max_num_class = *std::max_element(num_class.begin(), num_class.end());
+  const std::string missing_ctype_str = (threshold_ctype_str == "double" ? "long" : "int");
 
   gencode.SwitchToSourceFile("header.h");
   gencode.PushFragment(fmt::format(header_template, "threshold_ctype"_a = threshold_ctype_str,
       "leaf_output_ctype"_a = leaf_output_ctype_str, "dllexport"_a = DLLEXPORT_KEYWORD,
-      "num_target"_a = num_target, "max_num_class"_a = max_num_class));
+      "num_target"_a = num_target, "max_num_class"_a = max_num_class,
+      "missing_ctype"_a = missing_ctype_str));
 
   gencode.SwitchToSourceFile("main.c");
   gencode.PushFragment(fmt::format(main_start_template,


### PR DESCRIPTION
According to the comment in `predictor.h`, `Entry` works well as intended for float `ElementType` case.
But for the double 'ElementType' case, it is possible to misjudge valid floating point value as missing value.
Due to the size difference between int and double data types, `fvalue` represents valid floating point value even though `missing` is set to -1. And this means many other valid floating point values whose lower 4 bytes are 0xffffffff can also be misjudged as missing value by the check `!(data[xx].missing != -1)`.

Therefore, I would like to suggest changing the code a little bit like this PR.
In this PR, the type of `missing` becomes "long" when the `ElementType` is double, so `fvalue` represents `-NaN` when the `missing` is set to -1. As a result, there is no possibility for valid floating point values to be misjudged as missing values, as originally intended.